### PR TITLE
Guardar tweets antiguos

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -5,7 +5,7 @@ export const getIdFromURL = (url = '') => {
 };
 
 export const validateTweetstampURL = (url = '') => {
-  const regexp = /^https:\/\/tweetstamp\.org\/(\d{10,20})/;
+  const regexp = /^https:\/\/tweetstamp\.org\/(\d{4,20})/;
   return regexp.test(url);
 };
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -5,7 +5,7 @@ export const getIdFromURL = (url = '') => {
 };
 
 export const validateTweetstampURL = (url = '') => {
-  const regexp = /^https:\/\/tweetstamp\.org\/(\d{19})/;
+  const regexp = /^https:\/\/tweetstamp\.org\/(\d{10,20})/;
   return regexp.test(url);
 };
 


### PR DESCRIPTION
Los [snowflakes](https://developer.twitter.com/en/docs/basics/twitter-ids) tienen una longitud máxima de 20 caracteres (UInt64), pero he encontrado tweets del 2006 con una longitud mínima de 4

Existen tweets con ids de 2 caracteres, pero no estoy seguro que sea el caso de tweets salvadoreños 😬 

Resolves #7