### PR TITLE
Links y funcionalidad de copiar a portapapeles

### DIFF
--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -39,8 +39,9 @@ const Tweet = ({ data }: Props) => {
         </a>
         <div className="flex-grow text-right">
           <a
-            href={`https://twitter.com/${screen_name}`}
+            href={`https://twitter.com/${screen_name}/status/${id_str}`}
             className="inline-block"
+            title="Enlace a Tweet original"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -1,3 +1,4 @@
+import { Twitter as TwitterIcon } from 'react-feather';
 import { getDateFormat } from '../utils';
 
 import { TweetData } from '../types/index';
@@ -19,7 +20,13 @@ const Tweet = ({ data }: Props) => {
     <div className="p-4">
       <header className="flex items-center">
         <div className="w-12">
-          <img src={avatar} alt={name} className="rounded-full" title={name} />
+          <a
+            href={`https://twitter.com/${screen_name}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src={avatar} alt={name} className="rounded-full" title={name} />
+          </a>
         </div>
         <a
           href={`https://twitter.com/${screen_name}`}
@@ -30,6 +37,16 @@ const Tweet = ({ data }: Props) => {
           <h1 className="text-lg font-semibold">{name}</h1>
           <p className="text-sm text-gray-700 leading-tight">{`@${screen_name}`}</p>
         </a>
+        <div className="flex-grow text-right">
+          <a
+            href={`https://twitter.com/${screen_name}`}
+            className="inline-block"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <TwitterIcon className="text-right" />
+          </a>
+        </div>
       </header>
       <article className="my-4">
         <p>{full_text}</p>

--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -1,4 +1,9 @@
-import { Twitter as TwitterIcon, ExternalLink as ExternalLinkIcon } from 'react-feather';
+import {
+  Twitter as TwitterIcon,
+  ExternalLink as ExternalLinkIcon,
+  Copy as CopyIcon,
+} from 'react-feather';
+import Clipboard from 'react-clipboard.js';
 import { getDateFormat } from '../utils';
 
 import { TweetData } from '../types/index';
@@ -16,36 +21,34 @@ const Tweet = ({ data }: Props) => {
     created_at,
   } = data;
 
+  const stampLink = `https://tweetstamp.org/${id_str}`;
+  const tweetLink = `https://twitter.com/${screen_name}/status/${id_str}`;
+  const userLink = `https://twitter.com/${screen_name}`;
+
   return (
-    <div className="p-4">
+    <div className="tweet p-4">
       <header className="flex items-center">
         <div className="w-12">
-          <a
-            href={`https://twitter.com/${screen_name}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href={userLink} target="_blank" rel="noopener noreferrer">
             <img src={avatar} alt={name} className="rounded-full" title={name} />
           </a>
         </div>
-        <a
-          href={`https://twitter.com/${screen_name}`}
-          className="ml-3"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href={userLink} className="ml-3" target="_blank" rel="noopener noreferrer">
           <h1 className="text-lg font-semibold">{name}</h1>
           <p className="text-sm text-gray-700 leading-tight">{`@${screen_name}`}</p>
         </a>
-        <div className="flex-grow text-right">
+        <div className="flex flex-grow justify-end">
+          <Clipboard data-clipboard-text={stampLink}>
+            <CopyIcon id="clipboard" className="cursor-pointer invisible text-gray-500" />
+          </Clipboard>
           <a
-            href={`https://twitter.com/${screen_name}/status/${id_str}`}
-            className="inline-block"
+            href={tweetLink}
+            className="ml-3"
             title="Enlace a Tweet original"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <TwitterIcon className="text-right" />
+            <TwitterIcon />
           </a>
         </div>
       </header>
@@ -56,7 +59,7 @@ const Tweet = ({ data }: Props) => {
         <p className="text-sm my-1 text-gray-500">
           Publicado:{' '}
           <a
-            href={`https://tweetstamp.org/${id_str}`}
+            href={stampLink}
             className="inline-block"
             title="Fecha de creación de Tweet"
             target="_blank"
@@ -67,7 +70,7 @@ const Tweet = ({ data }: Props) => {
           </a>
         </p>
         {saved_at && (
-          <p className="text-sm my-1 text-gray-500 align-middle">
+          <p className="text-sm my-1 text-gray-500">
             Archivado: {getDateFormat(saved_at)}
           </p>
         )}

--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -1,4 +1,4 @@
-import { Twitter as TwitterIcon } from 'react-feather';
+import { Twitter as TwitterIcon, ExternalLink as ExternalLinkIcon } from 'react-feather';
 import { getDateFormat } from '../utils';
 
 import { TweetData } from '../types/index';
@@ -63,10 +63,11 @@ const Tweet = ({ data }: Props) => {
             rel="noopener noreferrer"
           >
             {getDateFormat(created_at)}
+            <ExternalLinkIcon className="inline-block ml-1 align-bottom w-4" />
           </a>
         </p>
         {saved_at && (
-          <p className="text-sm my-1 text-gray-500">
+          <p className="text-sm my-1 text-gray-500 align-middle">
             Archivado: {getDateFormat(saved_at)}
           </p>
         )}

--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback, useEffect } from 'react';
 import {
   Twitter as TwitterIcon,
   ExternalLink as ExternalLinkIcon,
@@ -25,8 +26,25 @@ const Tweet = ({ data }: Props) => {
   const tweetLink = `https://twitter.com/${screen_name}/status/${id_str}`;
   const userLink = `https://twitter.com/${screen_name}`;
 
+  const [copied, setCopied] = useState<boolean>(false);
+  const [timeoutRef, setTimeoutRef] = useState<any>(null);
+
+  const handleCopy = useCallback(() => {
+    setCopied(true);
+
+    const timeout = setTimeout(() => {
+      setCopied(false);
+    }, 1000);
+
+    setTimeoutRef(timeout);
+  }, []);
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef);
+  }, []);
+
   return (
-    <div className="tweet p-4">
+    <div className={`relative tweet p-4${copied ? ' copied' : ''}`}>
       <header className="flex items-center">
         <div className="w-12">
           <a href={userLink} target="_blank" rel="noopener noreferrer">
@@ -38,7 +56,7 @@ const Tweet = ({ data }: Props) => {
           <p className="text-sm text-gray-700 leading-tight">{`@${screen_name}`}</p>
         </a>
         <div className="flex flex-grow justify-end">
-          <Clipboard data-clipboard-text={stampLink}>
+          <Clipboard data-clipboard-text={stampLink} onSuccess={handleCopy}>
             <CopyIcon id="clipboard" className="cursor-pointer invisible text-gray-500" />
           </Clipboard>
           <a

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,6 +2091,11 @@
         "@types/node": "*"
       }
     },
+    "@types/clipboard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/clipboard/-/clipboard-2.0.1.tgz",
+      "integrity": "sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4139,6 +4144,16 @@
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -4906,6 +4921,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "denque": {
       "version": "1.4.1",
@@ -6402,6 +6422,14 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
+      }
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -11389,6 +11417,16 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-clipboard.js": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/react-clipboard.js/-/react-clipboard.js-2.0.16.tgz",
+      "integrity": "sha512-COwmnbrRbl8y4f/SjtonnJTeBRD03YzsHBL5on8iL/uyjERsMkKC7djtfmns7iRAbzadn/84MdpaqaQ3ITP47g==",
+      "requires": {
+        "@types/clipboard": "^2.0.1",
+        "clipboard": "^2.0.0",
+        "prop-types": "^15.5.0"
+      }
+    },
     "react-content-loader": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-5.0.4.tgz",
@@ -12137,6 +12175,11 @@
         "ajv": "^6.12.0",
         "ajv-keywords": "^3.4.1"
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "semver": {
       "version": "5.7.1",
@@ -13259,6 +13302,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11405,6 +11405,14 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-feather": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/react-feather/-/react-feather-2.0.8.tgz",
+      "integrity": "sha512-J0dCEOvOxpovHeOVj3+8mAhN3/UERTfX6rSxnV6x4E+0s+STY536jhSjRfpSvTQA0SSFjYr4KrpPfdsLmK+zZg==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-input-autosize": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react": "^16.13.1",
     "react-content-loader": "^5.0.4",
     "react-dom": "^16.13.1",
+    "react-feather": "^2.0.8",
     "react-select": "^3.1.0",
     "sweetalert2": "^9.10.13",
     "tailwindcss": "^1.4.6"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next-connect": "^0.6.6",
     "postcss-import": "^12.0.1",
     "react": "^16.13.1",
+    "react-clipboard.js": "^2.0.16",
     "react-content-loader": "^5.0.4",
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.8",

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -6,6 +6,21 @@
 
 /* Custom styles */
 
+.tweet.copied::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #000;
+  font-size: 3em;
+  content: '¡Copiado!';
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
 .tweet:hover #clipboard {
   visibility: visible;
 }

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -3,3 +3,9 @@
 /* purgecss end ignore */
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+
+/* Custom styles */
+
+.tweet:hover #clipboard {
+  visibility: visible;
+}


### PR DESCRIPTION
Cierra #1 

Para mejorar el diseño en general, necesitamos agregar antes algunos detalles de soporte para cada uno de los stamps, específicamente algunos enlaces y soportar copiar a portapapeles. Los cambios incluyen:

* El avatar en un enlace al perfil del usuario
* Variables de enlaces disponibles en componente
* Icono y soporte para copiar al portapapeles
* Icono con enlace a tweet original
* Icono para señalar enlace externo

Vista previa:
![image](https://user-images.githubusercontent.com/1808048/86545143-05f83a00-beea-11ea-826c-d940436a7b28.png)
